### PR TITLE
Correctly calculate Content-Length as a byte size

### DIFF
--- a/Sources/http.swift
+++ b/Sources/http.swift
@@ -49,16 +49,17 @@ public class HTTP {
       let clientSocket = accept(serverSocket, nil, nil)
 
       let msg = "Hello World"
+      let contentLength = msg.utf8.count
 
       echo(clientSocket, "HTTP/1.1 200 OK\n")
       echo(clientSocket, "Server: Swift Web Server\n")
-      echo(clientSocket, "Content-length: \(msg.characters.count)\n")
+      echo(clientSocket, "Content-length: \(contentLength)\n")
       echo(clientSocket, "Content-type: text-plain\n")
       echo(clientSocket, "\r\n")
 
       echo(clientSocket, msg)
 
-      print("Response sent: '\(msg)' - Length: \(msg.characters.count)")
+      print("Response sent: '\(msg)' - Length: \(contentLength)")
 
       close(clientSocket)
     }


### PR DESCRIPTION
The HTTP server currently is calculating Content-Length as a naive
character count, but the header is supposed to be the byte size of the
response contents. In the case of "Hello World", the two are equivalent,
but, if the response contained special characters, the Content-Length
would be incorrect:

``` swift
print("moose".characters.count) // 5
print("møøse".characters.count) // 5
print("møøse".utf8.count) // 7
```

For semantic reasons, and for people who are copying the source to serve
their own custom responses, we should provide the correct byte length.

Signed-off-by: David Celis me@davidcel.is
