### PR TITLE
Use double quotes in Package.swift to avoid a swift build error.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 import PackageDescription
 
 let package = Package(
-    name: 'swift-http'
+    name: "swift-http"
 )


### PR DESCRIPTION
At least on Ubuntu with the latest Swift & package manager build, I would get the following error before this modification:

```
/home/mz2/Projects/swift-http/Package.swift:4:11: error: single-quoted string literal found, use '"'
    name: 'swift-http'
          ^~~~~~~~~~~~
          "swift-http"
swift-build: exit(1): ["/home/mz2/usr/bin/swiftc", "--driver-mode=swift", "-I", "/home/mz2/usr/lib/swift/pm", "-L", "/home/mz2/usr/lib/swift/pm", "-lPackageDescription", "/home/mz2/Projects/swift-http/Package.swift"]
```
