### PR TITLE
Fix error when call swift build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 import PackageDescription
 
 let package = Package(
-    name: 'swift-http'
+    name: "swift-http"
 )


### PR DESCRIPTION
Fix a bug below,
/swiftcode/swift-http/Package.swift:4:11: error: single-quoted string literal found, use '"'
    name: 'swift-http'
          ^~~~~~~~~~~~
          "swift-http"
swift-build: exit(1): ["/usr/bin/swiftc", "--driver-mode=swift", "-I", "/usr/lib/swift/pm", "-L", "/usr/lib/swift/pm", "-lPackageDescription", "/swiftcode/swift-http/Package.swift"]
