### PR TITLE
Reduce size of built Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,17 @@
 FROM ubuntu:latest
 EXPOSE 8080
 RUN echo "Installing dependencies..."
-RUN apt-get update && apt-get install -y --force-yes wget build-essential clang rsync libpython-all-dev libedit-dev libicu52
+RUN apt-get update && apt-get install -y --force-yes \
+        wget \
+        build-essential \
+        clang \
+        rsync \
+        libpython-all-dev \
+        libedit-dev \
+        libicu52 && \
+        apt-get clean
 RUN cd /
-RUN wget https://swift.org/builds/ubuntu1404/swift-2.2-SNAPSHOT-2015-12-01-b/swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04.tar.gz
-RUN tar xzf swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04.tar.gz
-RUN rsync -a -v swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04/usr/ /usr
-RUN rm -rf swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04*
+RUN wget https://swift.org/builds/ubuntu1404/swift-2.2-SNAPSHOT-2015-12-01-b/swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04.tar.gz && \
+    tar xzf swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04.tar.gz && \
+    rsync -a -v swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04/usr/ /usr && \
+    rm -rf swift-2.2-SNAPSHOT-2015-12-01-b-ubuntu14.04*


### PR DESCRIPTION
Shrinks the swiftbox image from 1.22 GB to 849.3 MB.

The result of each Dockerfile line is saved to its own fs layer, so temporary files take up space in the image if they aren't removed in the same line they are created in. Also apt-get clean frees up a little space.
