### PR TITLE
Socket fixes

### DIFF
--- a/Sources/http.swift
+++ b/Sources/http.swift
@@ -15,7 +15,12 @@ public class HTTP {
 
   func echo(socket: Int32, _ output: String) {
    output.withCString { (bytes) in
-      send(socket, bytes, Int(strlen(bytes)), 0)
+      #if os(Linux)
+      let flags = Int32(MSG_NOSIGNAL)
+      #else
+      let flags = Int32(0)
+      #endif
+      send(socket, bytes, Int(strlen(bytes)), flags)
    }
   }
 
@@ -47,6 +52,11 @@ public class HTTP {
     #endif
 
     setsockopt(serverSocket, SOL_SOCKET, SO_RCVBUF, &bufferSize, socklen_t(sizeof(Int)))
+
+    #if !os(Linux)
+    var noSigPipe : Int32 = 1
+    setsockopt(serverSocket, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(sizeofValue(noSigPipe)))
+    #endif
 
     let serverBind = bind(serverSocket, sockaddr_cast(&serverAddress), socklen_t(UInt8(sizeof(sockaddr_in))))
     if (serverBind >= 0) {

--- a/Sources/http.swift
+++ b/Sources/http.swift
@@ -79,12 +79,14 @@ public class HTTP {
       echo(clientSocket, "Server: Swift Web Server\n")
       echo(clientSocket, "Content-length: \(contentLength)\n")
       echo(clientSocket, "Content-type: text-plain\n")
+      echo(clientSocket, "Connection: close\n")
       echo(clientSocket, "\r\n")
 
       echo(clientSocket, msg)
 
       print("Response sent: '\(msg)' - Length: \(contentLength)")
 
+      shutdown(clientSocket, Int32(SHUT_RDWR))
       close(clientSocket)
     }
   }


### PR DESCRIPTION
I was experimenting with deploying this code to a Cloud Foundry [instance](https://run.pivotal.io) and ran into a few issues related to the way the sockets were being handled. With these changes it seems to work great!
- Modify flags so that the system won't send SIGPIPE when the app writes to a socket that has been closed by the other end
- Use the `shutdown` call before `close` to try to get the network stack to send off all its data before tearing down the connection. According to [this](http://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable), just calling `shutdown` is not guaranteed to be enough, but it seems to be sufficient for this particular case.

Thanks for sharing this code!
